### PR TITLE
Added git to docker files

### DIFF
--- a/src/linux/alpine.3.10-x64/Dockerfile
+++ b/src/linux/alpine.3.10-x64/Dockerfile
@@ -7,4 +7,6 @@ LABEL maintainers="GitTools Maintainers"
 
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
+RUN apk add --no-cache git
+
 WORKDIR /app

--- a/src/linux/centos.7-x64/Dockerfile
+++ b/src/linux/centos.7-x64/Dockerfile
@@ -13,6 +13,7 @@ RUN rpm -Uvh https://packages.microsoft.com/config/rhel/7/packages-microsoft-pro
     && yum update cache
 
 RUN yum install -y dotnet-$DOTNET_VARIANT-$DOTNET_VERSION.x86_64 \
+    && yum install -y git \
     && yum clean all \
     && rm -rf /tmp/*
 

--- a/src/linux/debian.10-x64/Dockerfile
+++ b/src/linux/debian.10-x64/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -y dotnet-$DOTNET_VARIANT-$DOTNET_VERSION \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/* 
 
 WORKDIR /app

--- a/src/linux/debian.9-x64/Dockerfile
+++ b/src/linux/debian.9-x64/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -y dotnet-$DOTNET_VARIANT-$DOTNET_VERSION \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/* 
 
 WORKDIR /app

--- a/src/linux/fedora.30-x64/Dockerfile
+++ b/src/linux/fedora.30-x64/Dockerfile
@@ -12,6 +12,7 @@ ARG DOTNET_VARIANT
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc && dnf install wget -y \
     && wget -q -O /etc/yum.repos.d/microsoft-prod.repo https://packages.microsoft.com/config/fedora/30/prod.repo \
     && dnf install -y dotnet-$DOTNET_VARIANT-$DOTNET_VERSION \
+    && dnf install -y git \
     && rm -rf /tmp/*
 
 WORKDIR /app

--- a/src/linux/ubuntu.16.04-x64/Dockerfile
+++ b/src/linux/ubuntu.16.04-x64/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
 
 RUN apt-get update \
     && apt-get install -y dotnet-$DOTNET_VARIANT-$DOTNET_VERSION \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/* 
 
 WORKDIR /app

--- a/src/linux/ubuntu.18.04-x64/Dockerfile
+++ b/src/linux/ubuntu.18.04-x64/Dockerfile
@@ -7,4 +7,8 @@ LABEL maintainers="GitTools Maintainers"
 
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
+RUN apt-get update \
+    && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/* 
+
 WORKDIR /app


### PR DESCRIPTION
When working with the docker image some times is required to do git fetch or git branch, specially when composing a pipeline in Gitlab or Jenkings. Adding a git client to the docker images will reduce git's installation in the pipeline. 