### PR TITLE
replace net6.0 with net9.0

### DIFF
--- a/build/build/Utils/Constants.cs
+++ b/build/build/Utils/Constants.cs
@@ -12,7 +12,7 @@ public static class Constants
     public static readonly string[] DotnetVariants = ["sdk", "runtime"];
 
     public const string VersionLatest = "8.0";
-    public static readonly string[] DotnetVersions = [VersionLatest, "6.0"];
+    public static readonly string[] DotnetVersions = [VersionLatest, "9.0"];
 
     public const string AlpineLatest = "alpine.3.20";
     public const string CentosStreamLatest = "centos.stream.9";


### PR DESCRIPTION
This pull request includes a small change to the `Constants` class in the `build/build/Utils/Constants.cs` file. The change updates the `DotnetVersions` array to include version "9.0" instead of "6.0".

* [`build/build/Utils/Constants.cs`](diffhunk://#diff-e5958fb10a6e3adda5b9cadff7ca5c7591de377122f81872b5b08af996987650L15-R15): Updated `DotnetVersions` array to include "9.0" instead of "6.0".