### PR TITLE
ci: use Docker Hub OIDC for image publishing

### DIFF
--- a/.github/actions/build-deps-manifest/action.yml
+++ b/.github/actions/build-deps-manifest/action.yml
@@ -12,16 +12,30 @@ inputs:
     required: true
   docker_registry_username:
     description: 'Docker Registry Username'
-    required: true
+    required: false
   docker_registry_password:
     description: 'Docker Registry Password'
-    required: true
+    required: false
+  dockerhub_organization:
+    description: 'Docker Hub organization'
+    required: false
+  dockerhub_oidc_connection_id:
+    description: 'Docker Hub OIDC connection ID'
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    - name: Login to DockerHub
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry == 'docker.io' }}
+      uses: docker/login-action@v4
+      env:
+        DOCKERHUB_OIDC_CONNECTIONID: ${{ inputs.dockerhub_oidc_connection_id }}
+      with:
+        username: ${{ inputs.dockerhub_organization }}
+
     - name: Login to ${{ inputs.docker_registry }}
-      if: ${{ env.PUSH_IMAGES == 'true' }}
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry != 'docker.io' }}
       uses: docker/login-action@v4
       with:
         registry: ${{ inputs.docker_registry }}

--- a/.github/actions/build-deps/action.yml
+++ b/.github/actions/build-deps/action.yml
@@ -15,16 +15,30 @@ inputs:
     required: true
   docker_registry_username:
     description: 'Docker Registry Username'
-    required: true
+    required: false
   docker_registry_password:
     description: 'Docker Registry Password'
-    required: true
+    required: false
+  dockerhub_organization:
+    description: 'Docker Hub organization'
+    required: false
+  dockerhub_oidc_connection_id:
+    description: 'Docker Hub OIDC connection ID'
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    - name: Login to DockerHub
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry == 'docker.io' }}
+      uses: docker/login-action@v4
+      env:
+        DOCKERHUB_OIDC_CONNECTIONID: ${{ inputs.dockerhub_oidc_connection_id }}
+      with:
+        username: ${{ inputs.dockerhub_organization }}
+
     - name: Login to ${{ inputs.docker_registry }}
-      if: ${{ env.PUSH_IMAGES == 'true' }}
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry != 'docker.io' }}
       uses: docker/login-action@v4
       with:
         registry: ${{ inputs.docker_registry }}

--- a/.github/actions/build-images-manifest/action.yml
+++ b/.github/actions/build-images-manifest/action.yml
@@ -18,16 +18,30 @@ inputs:
     required: true
   docker_registry_username:
     description: 'Docker Registry Username'
-    required: true
+    required: false
   docker_registry_password:
     description: 'Docker Registry Password'
-    required: true
+    required: false
+  dockerhub_organization:
+    description: 'Docker Hub organization'
+    required: false
+  dockerhub_oidc_connection_id:
+    description: 'Docker Hub OIDC connection ID'
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    - name: Login to DockerHub
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry == 'docker.io' }}
+      uses: docker/login-action@v4
+      env:
+        DOCKERHUB_OIDC_CONNECTIONID: ${{ inputs.dockerhub_oidc_connection_id }}
+      with:
+        username: ${{ inputs.dockerhub_organization }}
+
     - name: Login to ${{ inputs.docker_registry }}
-      if: ${{ env.PUSH_IMAGES == 'true' }}
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry != 'docker.io' }}
       uses: docker/login-action@v4
       with:
         registry: ${{ inputs.docker_registry }}

--- a/.github/actions/build-images/action.yml
+++ b/.github/actions/build-images/action.yml
@@ -21,16 +21,30 @@ inputs:
     required: true
   docker_registry_username:
     description: 'Docker Registry Username'
-    required: true
+    required: false
   docker_registry_password:
     description: 'Docker Registry Password'
-    required: true
+    required: false
+  dockerhub_organization:
+    description: 'Docker Hub organization'
+    required: false
+  dockerhub_oidc_connection_id:
+    description: 'Docker Hub OIDC connection ID'
+    required: false
 
 runs:
   using: 'composite'
   steps:
+    - name: Login to DockerHub
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry == 'docker.io' }}
+      uses: docker/login-action@v4
+      env:
+        DOCKERHUB_OIDC_CONNECTIONID: ${{ inputs.dockerhub_oidc_connection_id }}
+      with:
+        username: ${{ inputs.dockerhub_organization }}
+
     - name: Login to ${{ inputs.docker_registry }}
-      if: ${{ env.PUSH_IMAGES == 'true' }}
+      if: ${{ env.PUSH_IMAGES == 'true' && inputs.docker_registry != 'docker.io' }}
       uses: docker/login-action@v4
       with:
         registry: ${{ inputs.docker_registry }}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ Under `.github/actions/`, each action wraps a call to `dotnet run/build.dll` via
 
 ### Credentials
 
-DockerHub credentials are retrieved at runtime from 1Password via `gittools/cicd/dockerhub-creds`, using `OP_SERVICE_ACCOUNT_TOKEN`. GHCR login uses `github.token`.
+Docker Hub publishing uses GitHub Actions OIDC through `docker/login-action`, with the `DOCKERHUB_OIDC_CONNECTIONID` repository variable and the `gittools` organization. GHCR login uses `github.token`.
 
 ## Key Conventions
 

--- a/.github/workflows/_build-deps-manifest.yml
+++ b/.github/workflows/_build-deps-manifest.yml
@@ -7,15 +7,16 @@ on:
       push_images:
         required: true
         type: boolean
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
-        required: false
+      dockerhub_oidc_connection_id:
+        required: true
+        type: string
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
   PUSH_IMAGES: ${{ inputs.push_images }}
 
 permissions:
+  id-token: write
   packages: write
 
 jobs:
@@ -45,13 +46,6 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker-setup
 
-      - name: Load DockerHub credentials
-        id: dockerhub-creds
-        if: env.PUSH_IMAGES == 'true'
-        uses: gittools/cicd/dockerhub-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
-        with:
-          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - name: Publish image manifest to DockerHub
         if: env.PUSH_IMAGES == 'true'
         uses: ./.github/actions/build-deps-manifest
@@ -59,8 +53,8 @@ jobs:
           docker_distro: ${{ matrix.docker_distro }}
           docker_registry: docker.io
           docker_registry_name: dockerhub
-          docker_registry_username: ${{ steps.dockerhub-creds.outputs.docker_username }}
-          docker_registry_password: ${{ steps.dockerhub-creds.outputs.docker_password }}
+          dockerhub_organization: gittools
+          dockerhub_oidc_connection_id: ${{ inputs.dockerhub_oidc_connection_id }}
 
       - name: Publish image manifest to GitHub
         uses: ./.github/actions/build-deps-manifest

--- a/.github/workflows/_build-deps.yml
+++ b/.github/workflows/_build-deps.yml
@@ -13,15 +13,16 @@ on:
       push_images:
         required: true
         type: boolean
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
-        required: false
+      dockerhub_oidc_connection_id:
+        required: true
+        type: string
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
   PUSH_IMAGES: ${{ inputs.push_images }}
 
 permissions:
+  id-token: write
   packages: write
 
 jobs:
@@ -51,13 +52,6 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker-setup
 
-      - name: Load DockerHub credentials
-        id: dockerhub-creds
-        if: env.PUSH_IMAGES == 'true'
-        uses: gittools/cicd/dockerhub-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
-        with:
-          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - name: Publish image to DockerHub
         if: env.PUSH_IMAGES == 'true'
         uses: ./.github/actions/build-deps
@@ -66,8 +60,8 @@ jobs:
           docker_distro: ${{ matrix.docker_distro }}
           docker_registry: docker.io
           docker_registry_name: dockerhub
-          docker_registry_username: ${{ steps.dockerhub-creds.outputs.docker_username }}
-          docker_registry_password: ${{ steps.dockerhub-creds.outputs.docker_password }}
+          dockerhub_organization: gittools
+          dockerhub_oidc_connection_id: ${{ inputs.dockerhub_oidc_connection_id }}
 
       - name: Publish image to GitHub
         uses: ./.github/actions/build-deps

--- a/.github/workflows/_build-images-manifest.yml
+++ b/.github/workflows/_build-images-manifest.yml
@@ -16,15 +16,16 @@ on:
       push_images:
         required: true
         type: boolean
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
-        required: false
+      dockerhub_oidc_connection_id:
+        required: true
+        type: string
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
   PUSH_IMAGES: ${{ inputs.push_images }}
 
 permissions:
+  id-token: write
   packages: write
 
 jobs:
@@ -56,13 +57,6 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker-setup
 
-      - name: Load DockerHub credentials
-        id: dockerhub-creds
-        if: env.PUSH_IMAGES == 'true'
-        uses: gittools/cicd/dockerhub-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
-        with:
-          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - name: Publish image manifest to DockerHub
         if: env.PUSH_IMAGES == 'true'
         uses: ./.github/actions/build-images-manifest
@@ -72,8 +66,8 @@ jobs:
           docker_distro: ${{ matrix.docker_distro }}
           docker_registry: docker.io
           docker_registry_name: dockerhub
-          docker_registry_username: ${{ steps.dockerhub-creds.outputs.docker_username }}
-          docker_registry_password: ${{ steps.dockerhub-creds.outputs.docker_password }}
+          dockerhub_organization: gittools
+          dockerhub_oidc_connection_id: ${{ inputs.dockerhub_oidc_connection_id }}
 
       - name: Publish image manifest to GitHub
         uses: ./.github/actions/build-images-manifest

--- a/.github/workflows/_build-images.yml
+++ b/.github/workflows/_build-images.yml
@@ -19,15 +19,16 @@ on:
       push_images:
         required: true
         type: boolean
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
-        required: false
+      dockerhub_oidc_connection_id:
+        required: true
+        type: string
 env:
   DOTNET_INSTALL_DIR: "./.dotnet"
   DOTNET_ROLL_FORWARD: "Major"
   PUSH_IMAGES: ${{ inputs.push_images }}
 
 permissions:
+  id-token: write
   packages: write
 
 jobs:
@@ -59,13 +60,6 @@ jobs:
       - name: Set up Docker
         uses: ./.github/actions/docker-setup
 
-      - name: Load DockerHub credentials
-        id: dockerhub-creds
-        if: env.PUSH_IMAGES == 'true'
-        uses: gittools/cicd/dockerhub-creds@824c3d773fb5d1b00c26b474ae88b7ce9ae555ee # v5
-        with:
-          op_service_account_token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
       - name: Publish image to DockerHub
         if: env.PUSH_IMAGES == 'true'
         uses: ./.github/actions/build-images
@@ -76,8 +70,8 @@ jobs:
           docker_distro: ${{ matrix.docker_distro }}
           docker_registry: docker.io
           docker_registry_name: dockerhub
-          docker_registry_username: ${{ steps.dockerhub-creds.outputs.docker_username }}
-          docker_registry_password: ${{ steps.dockerhub-creds.outputs.docker_password }}
+          dockerhub_organization: gittools
+          dockerhub_oidc_connection_id: ${{ inputs.dockerhub_oidc_connection_id }}
 
       - name: Publish image to GitHub
         uses: ./.github/actions/build-images

--- a/.github/workflows/build-deps.yml
+++ b/.github/workflows/build-deps.yml
@@ -47,10 +47,9 @@ jobs:
   build_deps:
     permissions:
       contents: read
+      id-token: write
       packages: write
     name: Build Deps (${{ matrix.arch }})
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     needs: [prepare]
     strategy:
       fail-fast: false
@@ -66,16 +65,17 @@ jobs:
       arch: ${{ matrix.arch }}
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       push_images: ${{ github.event_name != 'pull_request' && github.repository_owner == 'GitTools' }}
+      dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
 
   build_deps_manifests:
     permissions:
       contents: read
+      id-token: write
       packages: write
     name: Build Deps Manifests
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     needs: [prepare, build_deps]
     uses: ./.github/workflows/_build-deps-manifest.yml
     with:
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       push_images: ${{ github.event_name != 'pull_request' && github.repository_owner == 'GitTools' }}
+      dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -46,10 +46,9 @@ jobs:
   build_images:
     permissions:
       contents: read
+      id-token: write
       packages: write
     name: Build Images (${{ matrix.dotnet_variant }} - ${{ matrix.arch }})
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     needs: [ prepare ]
     strategy:
       fail-fast: false
@@ -71,14 +70,14 @@ jobs:
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       push_images: ${{ github.repository_owner == 'GitTools' }}
+      dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}
 
   build_images_manifest:
     permissions:
       contents: read
+      id-token: write
       packages: write
     name: Build Images Manifest (${{ matrix.dotnet_variant }})
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     needs: [ prepare, build_images ]
     strategy:
       fail-fast: false
@@ -87,8 +86,9 @@ jobs:
 
     uses: ./.github/workflows/_build-images-manifest.yml
     with:
-      runner: ${{ matrix.runner }}
+      runner: ubuntu-24.04
       dotnet_variant: ${{ matrix.dotnet_variant }}
       dotnet_versions: ${{ needs.prepare.outputs.dotnet_versions }}
       docker_distros: ${{ needs.prepare.outputs.docker_distros }}
       push_images: ${{ github.repository_owner == 'GitTools' }}
+      dockerhub_oidc_connection_id: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID }}


### PR DESCRIPTION
## Summary
- replace Docker Hub credentials with GitHub Actions OIDC in image and manifest publishing
- retain existing GHCR token authentication
- pass the Docker Hub connection ID through a repository variable

## Validation
- `git diff --check`
- Ruby YAML parsing for all changed workflows and composite actions
- `actionlint .github/workflows/*.yml`

The Docker Hub OIDC connection and `DOCKERHUB_OIDC_CONNECTIONID` repository variable will be configured before merging.